### PR TITLE
Bugfix for scheduler sizing and doc enhancement

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,5 +25,5 @@ python extract_metrics.py --help
 
 ## Example Usage
 ```
-python extract_metrics.py -p {PROJECT_ID} -e {ENVIRONMENT_NAME} -c {CLUSTER_NAME}
+python extract_metrics.py -p {PROJECT_ID} -e {ENVIRONMENT_NAME} -c {CLUSTER_NAME} -l {LOCATION}
 ```

--- a/gcc_metric_extracts/gcc_utils.py
+++ b/gcc_metric_extracts/gcc_utils.py
@@ -211,15 +211,15 @@ class AstroResourceMapper:
         cpu = self.utilization_df.select(scheduler_cpu_col).item()
 
         # by default set largest
-        sched = self.schedulers[-1]["size"]
+        recommended_sched = self.schedulers[-1]["size"]
         # if mem and cpu less than small or med, set
         for sched in self.schedulers:
             if memory < sched["memory"] and cpu < sched["cpu"]:
-                sched = sched["size"]
+                recommended_sched = sched["size"]
                 break
 
         self.utilization_df = self.utilization_df.with_columns(
-            pl.lit(sched).alias("astro_scheduler_size")
+            pl.lit(recommended_sched).alias("astro_scheduler_size")
         )
 
     def worker_size(


### PR DESCRIPTION
This fixes an error that can occur within `scheduler_size` when the calculated scheduler memory or cpu usage exceeds that of the max size scheduler.  

In these cases the criteria in the inner if loop are never met, so `sched` is never set to be a string representing the scheduler size and instead returns as the dict it is set to in the for loop.   Setting the recommended scheduler as `recommended_sched` rather than `sched` fixes this behavior.

This PR also updates the README to reflect the fact that a location argument is now required. 